### PR TITLE
Clean up async hook code

### DIFF
--- a/hooks/useAsync.ts
+++ b/hooks/useAsync.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppError, toAppError } from '@/lib/errors';
+
+export type AsyncStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface AsyncState<T> {
+  status: AsyncStatus;
+  data?: T;
+  error?: AppError;
+}
+
+export function useAsync<T>(options?: { autoResetMs?: number }) {
+  const [state, setState] = useState<AsyncState<T>>({ status: 'idle' });
+  const abortRef = useRef<AbortController | null>(null);
+  const resetTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const scheduleAutoReset = useCallback(() => {
+    if (!options?.autoResetMs) return;
+    if (resetTimeoutRef.current) {
+      clearTimeout(resetTimeoutRef.current);
+    }
+    resetTimeoutRef.current = setTimeout(
+      () => setState({ status: 'idle' }),
+      options.autoResetMs
+    );
+  }, [options?.autoResetMs]);
+
+  const run = useCallback(
+    async (fn: (signal: AbortSignal) => Promise<T>): Promise<T | undefined> => {
+      if (abortRef.current) abortRef.current.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setState({ status: 'loading' });
+      try {
+        const result = await fn(controller.signal);
+        setState({ status: 'success', data: result });
+        scheduleAutoReset();
+        return result;
+      } catch (e) {
+        const appErr = toAppError(e);
+        setState({ status: 'error', error: appErr });
+        scheduleAutoReset();
+        return undefined;
+      } finally {
+        abortRef.current = null;
+      }
+    },
+    [scheduleAutoReset]
+  );
+
+  const reset = useCallback(() => {
+    if (resetTimeoutRef.current) {
+      clearTimeout(resetTimeoutRef.current);
+      resetTimeoutRef.current = null;
+    }
+    setState({ status: 'idle' });
+  }, []);
+
+  // Clean up any pending timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current) {
+        clearTimeout(resetTimeoutRef.current);
+        resetTimeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  return { ...state, run, reset };
+}


### PR DESCRIPTION
Remove duplicate import block and leftover code in `hooks/useAsync.ts` to fix syntax errors and ensure a clean module structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-5880902d-6253-4154-a0db-776021eb1ea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5880902d-6253-4154-a0db-776021eb1ea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

