### PR TITLE
Check for dependency lock files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
       - run: npm i -g bun@1
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/.github/workflows/eas-preview.yml
+++ b/.github/workflows/eas-preview.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-      - run: npm ci
-      - run: npm i -g eas-cli
+      - run: npm i -g bun@1
+      - run: bun install --frozen-lockfile || bun install
+      - run: bun add -g eas-cli
       - name: Login to Expo
         run: eas whoami || eas login --token ${{ secrets.EXPO_TOKEN }}
       - name: Android APK (preview)

--- a/.github/workflows/eas-release.yml
+++ b/.github/workflows/eas-release.yml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-      - run: npm ci
-      - run: npm i -g eas-cli
+      - run: npm i -g bun@1
+      - run: bun install --frozen-lockfile || bun install
+      - run: bun add -g eas-cli
       - name: Login to Expo
         run: eas whoami || eas login --token ${{ secrets.EXPO_TOKEN }}
       - name: Android AAB (production)

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20, cache: npm }
+        with: { node-version: 20 }
 
       - run: npm i -g bun@1
       - run: bun install --frozen-lockfile || bun install

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install Bun
         run: npm i -g bun@1
@@ -63,7 +62,7 @@ jobs:
 
       - name: Security Audit
         run: |
-          npm audit --json > reports/security/audit.json || true
+          bun audit --json > reports/security/audit.json || true
           cat reports/security/audit.json
 
       - name: Semgrep Security Scan

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20, cache: npm }
-      - run: npm ci
-      - run: npm audit --audit-level=high || true
+        with: { node-version: 20 }
+      - run: npm i -g bun@1
+      - run: bun install --frozen-lockfile || bun install
+      - run: bun audit --audit-level=high || true


### PR DESCRIPTION
Update GitHub Actions workflows to use Bun instead of npm to resolve dependency lock file errors.

The project uses Bun, but the CI workflows were configured with npm commands (`npm ci`, `npm audit`, `npm i -g eas-cli`), which caused "Dependencies lock file is not found" errors because they were looking for npm/yarn lock files instead of `bun.lock`. This PR aligns the CI configuration with the project's package manager.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5ad24d6-8bfb-4839-ba91-d306fccb6535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5ad24d6-8bfb-4839-ba91-d306fccb6535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

