### PR TITLE
Check for dependency lock files

### DIFF
--- a/.github/workflows/eas-preview.yml
+++ b/.github/workflows/eas-preview.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-      - run: npm ci
+      - run: npm i -g bun@1
+      - run: bun install --frozen-lockfile || bun install
       - run: npm i -g eas-cli
       - name: Login to Expo
         run: eas whoami || eas login --token ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/eas-release.yml
+++ b/.github/workflows/eas-release.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-      - run: npm ci
+      - run: npm i -g bun@1
+      - run: bun install --frozen-lockfile || bun install
       - run: npm i -g eas-cli
       - name: Login to Expo
         run: eas whoami || eas login --token ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20, cache: npm }
+        with: { node-version: 20 }
 
       - run: npm i -g bun@1
       - run: bun install --frozen-lockfile || bun install

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install Bun
         run: npm i -g bun@1

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20, cache: npm }
-      - run: npm ci
+        with: { node-version: 20 }
+      - run: npm i -g bun@1
+      - run: bun install --frozen-lockfile || bun install
       - run: npm audit --audit-level=high || true


### PR DESCRIPTION
Align CI workflows with Bun package manager to resolve "Dependencies lock file not found" error.

The project uses Bun for package management, but some GitHub Actions workflows were configured to use `npm ci` and `cache: 'npm'`, which expected an `package-lock.json` file. This PR updates these workflows to use `bun install` and removes npm-specific caching, ensuring consistency with the project's chosen package manager and resolving the build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3b9a0a1-4e86-4dd7-bd45-027da1b62860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a3b9a0a1-4e86-4dd7-bd45-027da1b62860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

