### PR TITLE
Fix gitleaks workflow for passing checks

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,28 +1,35 @@
 name: Gitleaks
 
 on:
-  pull_request: {}
-  push: { branches: [ main, develop ] }
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 3 * * *" # optional nightly scan
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
 concurrency:
   group: gitleaks-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  scan:
+  gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
-      - uses: gitleaks/gitleaks-action@v2
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          args: --redact
+          fetch-depth: 0  # scan full history when needed
 
-- uses: gitleaks/gitleaks-action@v2
-  with:
-    args: --redact
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Gitleaks
+        uses: zricethezav/gitleaks-action@v2
+        with:
+          args: detect --redact --report-format sarif --report-path gitleaks.sarif
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif


### PR DESCRIPTION
Update Gitleaks workflow to fix failing status checks and properly integrate with GitHub Code Scanning.

The previous `gitleaks.yml` workflow had malformed YAML, lacked necessary `security-events: write` permissions, did not generate SARIF reports, and used a deprecated action, leading to consistent failures and a red ❌ on the main branch. This PR resolves these configuration issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-157f284c-7979-4159-8f4c-93def4a4730c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-157f284c-7979-4159-8f4c-93def4a4730c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

