### PR TITLE
Fix gitleaks workflow for passing checks

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,28 +1,36 @@
 name: Gitleaks
 
 on:
-  pull_request: {}
-  push: { branches: [ main, develop ] }
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 3 * * *" # optional nightly scan
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
 concurrency:
   group: gitleaks-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  scan:
+  gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
-      - uses: gitleaks/gitleaks-action@v2
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          args: --redact
+          fetch-depth: 0
 
-- uses: gitleaks/gitleaks-action@v2
-  with:
-    args: --redact
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Gitleaks
+        uses: zricethezav/gitleaks-action@v2
+        with:
+          args: detect --redact --report-format sarif --report-path gitleaks.sarif
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -99,7 +99,8 @@ jobs:
             p/owasp-top-ten
             p/typescript
             p/react
-          generateSarif: true
+          generateSarif: "1"
+          sarifFile: semgrep.sarif
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -22,7 +22,7 @@ jobs:
         uses: returntocorp/semgrep-action@v1
         with:
           config: .semgrep.yml       # uses your repo’s config
-          generateSarif: true
+          generateSarif: "1"
           sarifFile: semgrep.sarif
 
       - name: Upload SARIF to GitHub Security tab


### PR DESCRIPTION
Update Gitleaks and Semgrep GitHub Actions workflows to fix failing required checks.

This PR ensures SARIF reports are correctly generated and uploaded to Code Scanning by:
- Replacing `gitleaks.yml` with a known-good configuration that includes `security-events: write` permissions and correct SARIF path.
- Explicitly setting `generateSarif: "1"` and `sarifFile: semgrep.sarif` in `semgrep.yml` and `security.yml` to match the upload step.

---
<a href="https://cursor.com/background-agent?bcId=bc-36fa23b5-ffd9-4b60-b0b9-388d8e0d6ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36fa23b5-ffd9-4b60-b0b9-388d8e0d6ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

