### PR TITLE
Fix gitleaks workflow for passing checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main, develop]
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   install:
     name: Install Dependencies
@@ -163,6 +167,7 @@ jobs:
             p/secrets
             p/owasp-top-ten
           generateSarif: "1"
+          sarifFile: "semgrep.sarif"
       - name: Upload Semgrep SARIF results
         uses: github/codeql-action/upload-sarif@v3
         if: always()

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
 concurrency:
   group: gitleaks-${{ github.ref }}
@@ -15,14 +17,17 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
-      - uses: gitleaks/gitleaks-action@v2
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          args: --redact
+          fetch-depth: 0
 
-- uses: gitleaks/gitleaks-action@v2
-  with:
-    args: --redact
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Gitleaks
+        uses: zricethezav/gitleaks-action@v2
+        with:
+          args: detect --redact --report-format sarif --report-path gitleaks.sarif
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -100,6 +100,7 @@ jobs:
             p/typescript
             p/react
           generateSarif: true
+          sarifFile: semgrep.sarif
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Fix Gitleaks and Semgrep GitHub Actions workflows to correctly generate and upload SARIF reports, resolving failing required checks.

The Gitleaks workflow was misconfigured, leading to failed SARIF uploads and preventing the check from passing. Semgrep workflows had a mismatch between the generated SARIF path and the upload path, also causing failures. These changes ensure proper SARIF generation, correct file paths, and necessary permissions for successful uploads to GitHub Code Scanning.

---
<a href="https://cursor.com/background-agent?bcId=bc-d130cc67-f79d-4826-88b7-4fd00aae97f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d130cc67-f79d-4826-88b7-4fd00aae97f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

