### PR TITLE
Add project badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # 🌐 Linguamate — AI Language Tutor
 
-![Quality](https://github.com/ayais12210-hub/Linguamate-ai-tutor/actions/workflows/quality.yml/badge.svg)
-![Security](https://github.com/ayais12210-hub/Linguamate-ai-tutor/actions/workflows/security.yml/badge.svg)
-![Coverage](https://img.shields.io/badge/coverage-85%25+-brightgreen)
-![License](https://img.shields.io/badge/license-Proprietary-blue)
+<!-- Badges -->
+[![CI](https://github.com/ayais12210-hub/Linguamate-ai-tutor/actions/workflows/ci.yml/badge.svg)](https://github.com/ayais12210-hub/Linguamate-ai-tutor/actions/workflows/ci.yml)
+[![Quality](https://github.com/ayais12210-hub/Linguamate-ai-tutor/actions/workflows/quality.yml/badge.svg)](https://github.com/ayais12210-hub/Linguamate-ai-tutor/actions/workflows/quality.yml)
+[![Security](https://github.com/ayais12210-hub/Linguamate-ai-tutor/actions/workflows/security.yml/badge.svg)](https://github.com/ayais12210-hub/Linguamate-ai-tutor/actions/workflows/security.yml)
+[![Gitleaks](https://img.shields.io/badge/protected%20by-gitleaks-blue?logo=git&logoColor=white)](https://github.com/gitleaks/gitleaks)
+[![CodeQL](https://github.com/ayais12210-hub/Linguamate-ai-tutor/actions/workflows/codeql.yml/badge.svg)](https://github.com/ayais12210-hub/Linguamate-ai-tutor/actions/workflows/codeql.yml)
+[![Coverage](https://img.shields.io/badge/coverage-85%25+-brightgreen)](https://github.com/ayais12210-hub/Linguamate-ai-tutor/actions/workflows/ci.yml)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.3-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![React Native](https://img.shields.io/badge/React%20Native-0.76-61DAFB?logo=react&logoColor=white)](https://reactnative.dev/)
+[![Expo](https://img.shields.io/badge/Expo-53-000020?logo=expo&logoColor=white)](https://expo.dev/)
+[![License](https://img.shields.io/badge/License-Proprietary-red)](LICENSE)
 
 Cross-Platform AI-Powered Language Learning App  
 *(Expo + React Native + TypeScript + tRPC + Hono backend, with Rork Toolkit integration)*


### PR DESCRIPTION
Update README.md with a comprehensive set of professional badges to reflect the project's health, security, and tech stack.

The initial request included Go-specific badges, but the AI detected the project's TypeScript/React Native stack and generated a tailored set of badges, including CI, Quality, Security, Gitleaks, CodeQL, Coverage, TypeScript, React Native, Expo, and License.

---
<a href="https://cursor.com/background-agent?bcId=bc-46af5f4d-e8b3-4f14-b07b-b5509d993c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46af5f4d-e8b3-4f14-b07b-b5509d993c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

