### PR TITLE
Configure gitattributes for language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# GitHub Linguist configuration
+# Force TypeScript as the primary language and ignore generated files
+
+# Force TypeScript source files to be counted
+*.ts linguist-detectable=true
+*.tsx linguist-detectable=true
+
+# Ignore build artifacts and generated files (so they don't dominate language stats)
+dist/* linguist-vendored
+build/* linguist-vendored
+web-build/* linguist-vendored
+out/* linguist-vendored
+public/* linguist-vendored
+coverage/* linguist-vendored
+
+# Mark minified files as generated
+*.min.js linguist-generated=true
+*.min.css linguist-generated=true
+
+# Ignore other common build/generated directories
+node_modules/* linguist-vendored
+.next/* linguist-vendored
+.nuxt/* linguist-vendored
+.cache/* linguist-vendored
+.temp/* linguist-vendored
+.tmp/* linguist-vendored


### PR DESCRIPTION
Add `.gitattributes` to correctly classify the repository as TypeScript by ignoring generated build and coverage files.

GitHub's Linguist was misclassifying the repository as HTML due to the presence of numerous generated HTML files within build directories (e.g., `dist/`, `web-build/`) and specifically the `coverage/` directory from test reports. This PR configures Linguist to ignore these generated files, ensuring TypeScript is recognized as the primary language.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3241a2c-19fc-4625-8880-6e92fdc65e74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3241a2c-19fc-4625-8880-6e92fdc65e74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

