### PR TITLE
Automate github token creation for scans

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
         with:
+          token: ${{ github.token }}
           config-path: .gitleaks.toml
           redact: true
           sarif-file-output: gitleaks.sarif

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -29,7 +29,6 @@ jobs:
         env:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           config-path: .gitleaks.toml
           redact: true
           sarif-file-output: gitleaks.sarif

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -170,8 +170,6 @@ EOF
         uses: gitleaks/gitleaks-action@v2
         env:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
   # Security summary
   security-summary:

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -170,6 +170,8 @@ EOF
         uses: gitleaks/gitleaks-action@v2
         env:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+        with:
+          token: ${{ github.token }}
 
   # Security summary
   security-summary:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -136,7 +136,6 @@ jobs:
         env:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           args: --config-path=.gitleaks.toml --redact --verbose
   security-summary:
     name: Security Summary

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -136,6 +136,7 @@ jobs:
         env:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
         with:
+          token: ${{ github.token }}
           args: --config-path=.gitleaks.toml --redact --verbose
   security-summary:
     name: Security Summary


### PR DESCRIPTION
Remove explicit `GITHUB_TOKEN` from gitleaks-action steps to comply with the updated requirement to use the automatically created token.

---
<a href="https://cursor.com/background-agent?bcId=bc-5aa3e309-eb91-42c8-9234-445b3ca24e43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5aa3e309-eb91-42c8-9234-445b3ca24e43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hardened CI security scans by eliminating explicit repository token parameters, relying on default authentication without altering scan behavior or results.
* **Chores**
  * Aligned secret scanning configurations across workflows to remove manual token inputs while preserving existing options (e.g., verbosity, redaction, SARIF output).
  * Maintained current workflow structure and outputs; no impact on user-facing features or day-to-day usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->