### PR TITLE
Fix Gitleaks token and permissions in CI

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
         with:
-          token: ${{ github.token }}
           config-path: .gitleaks.toml
           redact: true
           sarif-file-output: gitleaks.sarif

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -169,9 +169,8 @@ EOF
       - name: 🔐 Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
-        with:
-          token: ${{ github.token }}
 
   # Security summary
   security-summary:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -134,9 +134,9 @@ jobs:
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
         with:
-          token: ${{ github.token }}
           args: --config-path=.gitleaks.toml --redact --verbose
   security-summary:
     name: Security Summary


### PR DESCRIPTION
fix(ci): add GITHUB_TOKEN to Gitleaks workflow

Adds the `GITHUB_TOKEN` environment variable to Gitleaks jobs and removes the deprecated `token` parameter to resolve CI failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8a00a90-2867-400c-a924-7e103be8f3a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e8a00a90-2867-400c-a924-7e103be8f3a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

