### PR TITLE
Fix gitleaks ci job token access

### DIFF
--- a/.github/workflows/ci-optimized.yml
+++ b/.github/workflows/ci-optimized.yml
@@ -10,6 +10,12 @@ concurrency:
   group: ci-optimized-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+  actions: read
+
 env:
   NODE_VERSION: '20'
   BUN_VERSION: 'latest'


### PR DESCRIPTION
Add required permissions to `ci-optimized.yml` to fix Gitleaks job failures on pull requests.

The Gitleaks job in `ci-optimized.yml` was failing on pull requests because it lacked the necessary permissions (`contents: read`, `security-events: write`, etc.) to access repository content and write security events, even though the `GITHUB_TOKEN` was correctly configured. This PR resolves that by explicitly granting these permissions at the workflow level.

---
<a href="https://cursor.com/background-agent?bcId=bc-79503658-b43d-47a2-a543-ae97af9b7020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79503658-b43d-47a2-a543-ae97af9b7020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

